### PR TITLE
Makefile: Add missing cleaning for .o files in src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ Image.gz: Image
 LinuxSimpleMassStorage.efi: Image LinuxSimpleMassStorage.inf
 	cp $< $@
 clean-bin:
-	rm -f initramfs.cpio init *.o Image Image.gz
+	rm -f initramfs.cpio init *.o Image Image.gz src/*.o src/*.a src/fastboot/*.o
 clean-musl:
 	$(MAKE) -C musl clean
 clean-kernel:


### PR DESCRIPTION
'make clean' doesn't clean the .o and .a files in src/ folder.
Fix it. 

Signed-off-by: Molly Sophia <mollysophia379@gmail.com>